### PR TITLE
Rails api

### DIFF
--- a/actionpack/lib/action_controller.rb
+++ b/actionpack/lib/action_controller.rb
@@ -16,7 +16,6 @@ module ActionController
   autoload :FormBuilder
 
   autoload_under "metal" do
-    autoload :Compatibility
     autoload :ConditionalGet
     autoload :Cookies
     autoload :DataStreaming

--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -5,14 +5,14 @@ require 'action_controller/log_subscriber'
 module ActionController
   # API Controller is a lightweight version of <tt>ActionController::Base</tt>,
   # created for applications that don't require all functionality that a complete
-  # \Rails controller provides, allowing you to create faster controllers for
-  # example for API only applications.
+  # \Rails controller provides, allowing you to create controllers with just the
+  # features that you need for API only applications.
   #
   # An API Controller is different from a normal controller in the sense that
   # by default it doesn't include a number of features that are usually required
   # by browser access only: layouts and templates rendering, cookies, sessions,
-  # flash, assets, and so on. This makes the entire controller stack thinner and
-  # faster, suitable for API applications. It doesn't mean you won't have such
+  # flash, assets, and so on. This makes the entire controller stack thinner,
+  # suitable for API applications. It doesn't mean you won't have such
   # features if you need them: they're all available for you to include in
   # your application, they're just not part of the default API Controller stack.
   #

--- a/actionpack/lib/action_controller/api.rb
+++ b/actionpack/lib/action_controller/api.rb
@@ -85,25 +85,6 @@ module ActionController
   class API < Metal
     abstract!
 
-    module Compatibility
-      def cache_store; end
-      def cache_store=(*); end
-      def assets_dir=(*); end
-      def javascripts_dir=(*); end
-      def stylesheets_dir=(*); end
-      def page_cache_directory=(*); end
-      def asset_path=(*); end
-      def asset_host=(*); end
-      def relative_url_root=(*); end
-      def perform_caching=(*); end
-      def helpers_path=(*); end
-      def allow_forgery_protection=(*); end
-      def helper_method(*); end
-      def helper(*); end
-    end
-
-    extend Compatibility
-
     # Shortcut helper that returns all the ActionController::API modules except the ones passed in the argument:
     #
     #   class MetalController

--- a/actionpack/lib/action_dispatch/routing/inspector.rb
+++ b/actionpack/lib/action_dispatch/routing/inspector.rb
@@ -45,22 +45,12 @@ module ActionDispatch
       end
 
       def internal?
-        internal_controller? || internal_asset?
+        controller.to_s =~ %r{\Arails/(info|mailers|welcome)}
       end
 
       def engine?
         rack_app.respond_to?(:routes)
       end
-
-      private
-        def internal_controller?
-          controller.to_s =~ %r{\arails/(info|mailers|welcome)}
-        end
-
-        def internal_asset?
-          Rails.application.config.respond_to?(:assets) &&
-            path =~ %r{\a#{Rails.application.config.assets.prefix}\z}
-        end
     end
 
     ##

--- a/actionpack/lib/action_dispatch/routing/mapper.rb
+++ b/actionpack/lib/action_dispatch/routing/mapper.rb
@@ -1042,7 +1042,7 @@ module ActionDispatch
         class Resource #:nodoc:
           attr_reader :controller, :path, :options, :param
 
-          def initialize(entities, options = {})
+          def initialize(entities, api_only = false, options = {})
             @name       = entities.to_s
             @path       = (options[:path] || @name).to_s
             @controller = (options[:controller] || @name).to_s
@@ -1050,10 +1050,15 @@ module ActionDispatch
             @param      = (options[:param] || :id).to_sym
             @options    = options
             @shallow    = false
+            @api_only   = api_only
           end
 
           def default_actions
-            [:index, :create, :new, :show, :update, :destroy, :edit]
+            if @api_only
+              [:index, :create, :show, :update, :destroy]
+            else
+              [:index, :create, :new, :show, :update, :destroy, :edit]
+            end
           end
 
           def actions
@@ -1120,7 +1125,7 @@ module ActionDispatch
         end
 
         class SingletonResource < Resource #:nodoc:
-          def initialize(entities, options)
+          def initialize(entities, api_only, options)
             super
             @as         = nil
             @controller = (options[:controller] || plural).to_s
@@ -1128,7 +1133,11 @@ module ActionDispatch
           end
 
           def default_actions
-            [:show, :create, :update, :destroy, :new, :edit]
+            if @api_only
+              [:show, :create, :update, :destroy]
+            else
+              [:show, :create, :update, :destroy, :new, :edit]
+            end
           end
 
           def plural
@@ -1178,7 +1187,7 @@ module ActionDispatch
             return self
           end
 
-          resource_scope(:resource, SingletonResource.new(resources.pop, options)) do
+          resource_scope(:resource, SingletonResource.new(resources.pop, api_only?, options)) do
             yield if block_given?
 
             concerns(options[:concerns]) if options[:concerns]
@@ -1336,7 +1345,7 @@ module ActionDispatch
             return self
           end
 
-          resource_scope(:resources, Resource.new(resources.pop, options)) do
+          resource_scope(:resources, Resource.new(resources.pop, api_only?, options)) do
             yield if block_given?
 
             concerns(options[:concerns]) if options[:concerns]
@@ -1764,6 +1773,10 @@ module ActionDispatch
               end
               delete :destroy if parent_resource.actions.include?(:destroy)
             end
+          end
+
+          def api_only?
+            @set.api_only?
           end
       end
 

--- a/actionpack/lib/action_dispatch/routing/route_set.rb
+++ b/actionpack/lib/action_dispatch/routing/route_set.rb
@@ -319,17 +319,23 @@ module ActionDispatch
       end
 
       def self.new_with_config(config)
+        route_set_config = DEFAULT_CONFIG
+
+        # engines apparently don't have this set
         if config.respond_to? :relative_url_root
-          new Config.new config.relative_url_root
-        else
-          # engines apparently don't have this set
-          new
+          route_set_config.relative_url_root = config.relative_url_root
         end
+
+        if config.respond_to? :api_only
+          route_set_config.api_only = config.api_only
+        end
+
+        new route_set_config
       end
 
-      Config = Struct.new :relative_url_root
+      Config = Struct.new :relative_url_root, :api_only
 
-      DEFAULT_CONFIG = Config.new(nil)
+      DEFAULT_CONFIG = Config.new(nil, false)
 
       def initialize(config = DEFAULT_CONFIG)
         self.named_routes = NamedRouteCollection.new
@@ -350,6 +356,10 @@ module ActionDispatch
 
       def relative_url_root
         @config.relative_url_root
+      end
+
+      def api_only?
+        @config.api_only
       end
 
       def request_class

--- a/actionpack/test/controller/api/conditional_get_test.rb
+++ b/actionpack/test/controller/api/conditional_get_test.rb
@@ -29,13 +29,13 @@ class ConditionalGetApiTest < ActionController::TestCase
     @last_modified = Time.now.utc.beginning_of_day.httpdate
   end
 
-  def test_request_with_bang_gets_last_modified
+  def test_request_gets_last_modified
     get :two
     assert_equal @last_modified, @response.headers['Last-Modified']
     assert_response :success
   end
 
-  def test_request_with_bang_obeys_last_modified
+  def test_request_obeys_last_modified
     @request.if_modified_since = @last_modified
     get :two
     assert_response :not_modified

--- a/actionview/lib/action_view/railtie.rb
+++ b/actionview/lib/action_view/railtie.rb
@@ -48,8 +48,10 @@ module ActionView
       end
     end
 
-    rake_tasks do
-      load "action_view/tasks/dependencies.rake"
+    rake_tasks do |app|
+      unless app.config.api_only
+        load "action_view/tasks/dependencies.rake"
+      end
     end
   end
 end

--- a/railties/lib/rails/generators/rails/app/app_generator.rb
+++ b/railties/lib/rails/generators/rails/app/app_generator.rb
@@ -251,17 +251,19 @@ module Rails
       end
 
       def create_tmp_files
-        build(:tmp) unless options[:api]
+        build(:tmp)
       end
 
       def create_vendor_files
-        build(:vendor) unless options[:api]
+        build(:vendor)
       end
 
       def delete_app_assets_if_api_option
         if options[:api]
           remove_dir 'app/assets'
           remove_dir 'lib/assets'
+          remove_dir 'tmp/cache/assets'
+          remove_dir 'vendor/assets'
         end
       end
 

--- a/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
+++ b/railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb
@@ -24,9 +24,7 @@ module Rails
         end
 
         # inserts the primary resource
-        resources = "resources :#{file_name.pluralize}"
-        resources << ", except: [:new, :edit]" if options.api?
-        write(resources, route_length + 1)
+        write("resources :#{file_name.pluralize}", route_length + 1)
 
         # ends blocks
         regular_class_path.each_index do |index|

--- a/railties/test/generators/api_app_generator_test.rb
+++ b/railties/test/generators/api_app_generator_test.rb
@@ -72,6 +72,8 @@ class ApiAppGeneratorTest < Rails::Generators::TestCase
       test/controllers
       test/integration
       test/models
+      tmp
+      vendor
     )
     files.concat %w(bin/bundle bin/rails bin/rake)
     files

--- a/railties/test/generators/resource_generator_test.rb
+++ b/railties/test/generators/resource_generator_test.rb
@@ -85,10 +85,4 @@ class ResourceGeneratorTest < Rails::Generators::TestCase
       assert_no_match(/resources :accounts$/, route)
     end
   end
-
-  def test_api_only_does_not_generate_edit_route
-    run_generator ["Account", "--api"]
-
-    assert_file "config/routes.rb", /resources :accounts, except: \[:new, :edit\]$/
-  end
 end


### PR DESCRIPTION
- Resources in the `config/routes.rb` will not generate `:new` or `:edit` actions for api applications.
- and more...
